### PR TITLE
Added a link above the Active Projects Google Doc <iframe> to allow the user to open that content in a separate window / tab.

### DIFF
--- a/_docs/projects.md
+++ b/_docs/projects.md
@@ -6,6 +6,9 @@ permalink: /docs/projects/
 <div class="row">
   <div class="col-sm-12">
     <h3 class="text-center">Current Projects</h3>
+    <div class="text-center">
+      <a href="https://docs.google.com/document/d/e/2PACX-1vRxyQGbgNroYwpQVPIPYV-EhGFAJMMWa__pqx2Ou6CqbJ9VEaWZWnYHQUqLWrg_pe0pprvs2Y_ajPm_/pub?embedded=true" target="_blank">Open just the Active Projects Google Doc in a separate window / tab</a>
+    </div>
     <div class="iframe-container"><iframe width="600" height="200" src="https://docs.google.com/document/d/e/2PACX-1vRxyQGbgNroYwpQVPIPYV-EhGFAJMMWa__pqx2Ou6CqbJ9VEaWZWnYHQUqLWrg_pe0pprvs2Y_ajPm_/pub?embedded=true"></iframe>
   </div>
   <div class="col-sm-6">


### PR DESCRIPTION
Added a link above the Active Projects Google Doc <iframe> to allow the user to open that content in a separate window / tab.

Viewing that content on a page by itself is more convenient for the
user than viewing it inside a tiny <iframe>, especially on a mobile
device.  The user can see more content at a glance, and scrolling is
a lot easier.