### PR TITLE
Update “Donate” page link

### DIFF
--- a/about.html
+++ b/about.html
@@ -31,7 +31,7 @@
           <a href="./about.html">About Us</a>
           <a href="./projects.html">Projects</a>
           <a href="https://www.meetup.com/Code-for-San-Jose/" target="_blank" rel="noopener noref">Events</a>
-          <a href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Code%20for%20San%20Jose"
+          <a href="https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20San%20Jose&utm_source=CodeforSanJose%20site"
             target="_blank" rel="noopener noref">Donate</a>
           <a href="./faq.html">FAQ</a>
         </div>
@@ -150,7 +150,7 @@
           <a href="./volunteer.html">Volunteer</a>
           <a href="./about.html">About Us</a>
           <a href="./projects.html">Projects</a>
-          <a href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Code%20for%20San%20Jose"
+          <a href="https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20San%20Jose&utm_source=CodeforSanJose%20site"
             target="_blank" rel="noopener noref">Donate</a>
           <a href="https://www.meetup.com/Code-for-San-Jose/" target="_blank" rel="noopener noref">Events</a>
           <a href="./faq.html">FAQ</a>

--- a/faq.html
+++ b/faq.html
@@ -31,7 +31,7 @@
                     <a href="./about.html">About Us</a>
                     <a href="./projects.html">Projects</a>
                     <a href="https://www.meetup.com/Code-for-San-Jose/" target="_blank" rel="noopener noref">Events</a>
-                    <a href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Code%20for%20San%20Jose"
+                    <a href="https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20San%20Jose&utm_source=CodeforSanJose%20site"
                         target="_blank" rel="noopener noref">Donate</a>
                     <a href="./faq.html">FAQ</a>
                 </div>
@@ -270,7 +270,7 @@
                     <a href="./volunteer.html">Volunteer</a>
                     <a href="./about.html">About Us</a>
                     <a href="./projects.html">Projects</a>
-                    <a href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Code%20for%20San%20Jose"
+                    <a href="https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20San%20Jose&utm_source=CodeforSanJose%20site"
                         target="_blank" rel="noopener noref">Donate</a>
                     <a href="https://www.meetup.com/Code-for-San-Jose/" target="_blank" rel="noopener noref">Events</a>
                     <a href="./faq.html">FAQ</a>

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
           <a href="./about.html">About Us</a>
           <a href="./projects.html">Projects</a>
           <a href="https://www.meetup.com/Code-for-San-Jose/" target="_blank" rel="noopener noref">Events</a>
-          <a href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Code%20for%20San%20Jose"
+          <a href="https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20San%20Jose&utm_source=CodeforSanJose%20site"
             target="_blank" rel="noopener noref">Donate</a>
           <a href="./faq.html">FAQ</a>
         </div>
@@ -126,7 +126,7 @@
         </div>
         <div class="cta-card">
           <i class="fas fa-5x fa-hand-holding-heart"></i>
-          <a href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Code%20for%20San%20Jose"
+          <a href="https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20San%20Jose&utm_source=CodeforSanJose%20site"
             target="_blank" rel="noref noopener">Donate</a>
           <p>Help us keep the lights on and feed our volunteers!</p>
         </div>
@@ -185,7 +185,7 @@
           <a href="./volunteer.html">Volunteer</a>
           <a href="./about.html">About Us</a>
           <a href="./projects.html">Projects</a>
-          <a href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Code%20for%20San%20Jose"
+          <a href="https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20San%20Jose&utm_source=CodeforSanJose%20site"
             target="_blank" rel="noopener noref">Donate</a>
           <a href="https://www.meetup.com/Code-for-San-Jose/" target="_blank" rel="noopener noref">Events</a>
           <a href="./faq.html">FAQ</a>

--- a/projects.html
+++ b/projects.html
@@ -35,7 +35,7 @@
                     <a href="./about.html">About Us</a>
                     <a href="./projects.html">Projects</a>
                     <a href="https://www.meetup.com/Code-for-San-Jose/" target="_blank" rel="noopener noref">Events</a>
-                    <a href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Code%20for%20San%20Jose"
+                    <a href="https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20San%20Jose&utm_source=CodeforSanJose%20site"
                         target="_blank" rel="noopener noref">Donate</a>
                     <a href="./faq.html">FAQ</a>
                 </div>
@@ -107,7 +107,7 @@
                     <a href="./volunteer.html">Volunteer</a>
                     <a href="./about.html">About Us</a>
                     <a href="./projects.html">Projects</a>
-                    <a href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Code%20for%20San%20Jose"
+                    <a href="https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20San%20Jose&utm_source=CodeforSanJose%20site"
                         target="_blank" rel="noopener noref">Donate</a>
                     <a href="https://www.meetup.com/Code-for-San-Jose/" target="_blank" rel="noopener noref">Events</a>
                     <a href="./faq.html">FAQ</a>

--- a/volunteer.html
+++ b/volunteer.html
@@ -31,7 +31,7 @@
           <a href="./about.html">About Us</a>
           <a href="./projects.html">Projects</a>
           <a href="https://www.meetup.com/Code-for-San-Jose/" target="_blank" rel="noopener noref">Events</a>
-          <a href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Code%20for%20San%20Jose"
+          <a href="https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20San%20Jose&utm_source=CodeforSanJose%20site"
             target="_blank" rel="noopener noref">Donate</a>
           <a href="./faq.html">FAQ</a>
         </div>
@@ -346,7 +346,7 @@
           <a href="./volunteer.html">Volunteer</a>
           <a href="./about.html">About Us</a>
           <a href="./projects.html">Projects</a>
-          <a href="https://secure.codeforamerica.org/page/contribute/donate-to-a-brigade-today?source_codes=Brigade-page&brigade=Code%20for%20San%20Jose"
+          <a href="https://www.codeforamerica.org/donate-to-a-brigade?utm_campaign=Code%20for%20San%20Jose&utm_source=CodeforSanJose%20site"
             target="_blank" rel="noopener noref">Donate</a>
           <a href="https://www.meetup.com/Code-for-San-Jose/" target="_blank" rel="noopener noref">Events</a>
           <a href="./faq.html">FAQ</a>


### PR DESCRIPTION
We at Code for America created this new donate page [seven months
ago][1] because the old donate page required a high maintenance
burden and created an unnecessary duplication in our process.

This commit updates your website to link to the new Donate page.

[1]: https://groups.google.com/a/codeforamerica.org/g/brigadeleads/c/At0loymFW0I/m/OVC-W90yEAAJ