### PR TITLE
Delete redirect to codeforsanjose.org

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-www.codeforsanjose.org


### PR DESCRIPTION
As of Monday, codeforsanjose.org is maintained by a third-party CMS instead of GitHub Pages. Nothing published by GitHub Pages remains accessible through codeforsanjose.org. Additionally, nothing published by GitHub Pages is accessible through codeforsanjose.github.io either, because this CNAME file causes that domain to redirect to the [custom domain](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/troubleshooting-custom-domains-and-github-pages#cname-errors) codeforsanjose.org. To unblock projects that require access to a GitHub Pages–managed website, I’ve temporarily removed this file.

/ref https://github.com/isaacs/github/issues/1213#issuecomment-420721507
/cc @impiaaa