### PR TITLE
Add Code of Conduct Page

### DIFF
--- a/codeofconduct.html
+++ b/codeofconduct.html
@@ -42,11 +42,11 @@
                   <li>Don’t assume everyone has the same context, and encourage questions.</li>
                   <li>Find a way for people to be productive with their skills (technical and not) and energy. Use language such as “yes/and”, not “no/but.”</li>
                   <li>Encourage members and participants to listen as much as they speak.</li>
-                  <li>Strive to build tools that are open and free technology for public use. Activities that aim to foster public use, not private gain, are prioritized.</li>
+                  <li>Strive to build tools that are open and free for public use. Activities that aim to foster public use, not private gain, are prioritized.</li>
                   <li>Prioritize access for and input from those who are traditionally excluded from the civic process.</li>
                   <li>Work to ensure that the community is well-represented in the planning, design, and implementation of civic tech. This includes encouraging participation from women, minorities, and traditionally marginalized groups.</li>
                   <li>Actively involve community groups and those with subject matter expertise in the decision-making process.</li>
-                  <li>Ensure that the relationships and conversations between community members, the local government staff and community partners remain respectful, participatory, and productive.</li>
+                  <li>Ensure that the relationships and conversations between community members, the local government staff, and community partners remain respectful, participatory, and productive.</li>
                   <li>Provide an environment where people are free from discrimination or harassment.</li>
                 </ol>
               

--- a/codeofconduct.html
+++ b/codeofconduct.html
@@ -27,14 +27,12 @@
 <body>
             <div class="container">
 
-                <h1>Code of Conduct</h1>
+                <h1>>Code for San Jose's Code of Conduct</h1>
               
                 <p>This document is adapted from Code for America’s Code of Conduct and Anti-Harrassment Policy.</p>
                 
                 <hr>
-              
-                <h3>Code for San Jose's Code of Conduct</h3>
-              
+                            
                 <p>The Code for San Jose community expects that Code for San Jose network activities, events, and digital forums:</p>
               
                 <ol>

--- a/codeofconduct.html
+++ b/codeofconduct.html
@@ -1,0 +1,98 @@
+<!DOCTYPE html>
+ <html lang="en">
+    <head>
+ <title>Code for San José - Code of Conduct</title>
+
+ <meta charset="UTF-8" />
+ <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+ <link rel="stylesheet" href="./assets/css/global.min.css" />
+ <link rel="stylesheet" href="./assets/css/header.min.css" />
+ <link rel="stylesheet" href="./assets/css/footer.min.css" />
+ <link rel="stylesheet" href="./assets/css/about.min.css" />
+ <script src="https://kit.fontawesome.com/a5c8bf6536.js" crossorigin="anonymous"></script>
+ <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,600i,700,700i&display=swap"
+   rel="stylesheet" />
+ <script src="./assets/js/app.js"></script>
+
+ <!-- Global site tag (gtag.js) - Google Analytics -->
+ <script async src="https://www.googletagmanager.com/gtag/js?id=G-26B6FB8T8P"></script>
+ <script>
+   window.dataLayer = window.dataLayer || [];
+   function gtag(){dataLayer.push(arguments);}
+   gtag('js', new Date());
+   gtag('config', 'G-26B6FB8T8P');
+ </script>
+</head>
+
+<body>
+            <div class="container">
+
+                <h1>Code of Conduct</h1>
+              
+                <p>This document is adapted from Code for America’s Code of Conduct and Anti-Harrassment Policy.</p>
+                
+                <hr>
+              
+                <h3>Code for San Jose's Code of Conduct</h3>
+              
+                <p>The Code for San Jose community expects that Code for San Jose network activities, events, and digital forums:</p>
+              
+                <ol>
+                  <li>Are a safe and respectful environment for all participants.</li>
+                  <li>Are a place where people are free to fully express their identities.</li>
+                  <li>Presume the value of others. Everyone’s ideas, skills, and contributions have value.</li>
+                  <li>Don’t assume everyone has the same context, and encourage questions.</li>
+                  <li>Find a way for people to be productive with their skills (technical and not) and energy. Use language such as “yes/and”, not “no/but.”</li>
+                  <li>Encourage members and participants to listen as much as they speak.</li>
+                  <li>Strive to build tools that are open and free technology for public use. Activities that aim to foster public use, not private gain, are prioritized.</li>
+                  <li>Prioritize access for and input from those who are traditionally excluded from the civic process.</li>
+                  <li>Work to ensure that the community is well-represented in the planning, design, and implementation of civic tech. This includes encouraging participation from women, minorities, and traditionally marginalized groups.</li>
+                  <li>Actively involve community groups and those with subject matter expertise in the decision-making process.</li>
+                  <li>Ensure that the relationships and conversations between community members, the local government staff and community partners remain respectful, participatory, and productive.</li>
+                  <li>Provide an environment where people are free from discrimination or harassment.</li>
+                </ol>
+              
+                <p>Code for San Jose reserves the right to ask anyone in violation of these policies not to participate in Code for America network activities, events, and digital forums.</p>
+              
+                <h3>Code for San Jose's Anti-Harassment Policy</h3>
+              
+                <p>This anti-harassment policy is based on the example <a href="http://geekfeminism.wikia.com/wiki/Conference_anti-harassment/Policy">policy</a> from the Geek Feminism wiki, created by the Ada Initiative and other volunteers.</p>
+              
+                <p>This policy is based on several other policies, including the Ohio LinuxFest anti-harassment policy, written by Esther Filderman and Beth Lynn Eicher, and the Con Anti-Harassment Project. Mary Gardiner, Valerie Aurora, Sarah Smith, and Donna Benjamin generalized the policies and added supporting material. Many members of LinuxChix, Geek Feminism and other groups contributed to this work.</p>
+                <hr>
+                <p>All Code for San Jose network activities, events, and digital forums and their staff, presenters, and participants are held to an anti-harassment policy, included below.</p>
+              
+                <p>In addition to governing our own events by this policy, Code for San Jose will only lend our brand and fund groups that offer an anti-harassment policy to their attendees. For information on how to offer an anti-harassment policy to your group, see this <a href="https://docs.google.com/document/d/1Zg2FDt7awgfCmdcbzMwKHMb1A7KDOhs_z7ibCb3TLLQ/">guide from Code for America.</a></p>
+              
+                <p>Code for San Jose is dedicated to providing a harassment-free experience for everyone regardless of gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, or religion. We do not tolerate harassment of staff, presenters, and participants in any form. Sexual language and imagery is not appropriate for any Code for America event or network activity, including talks. Anyone in violation of these policies may expelled from Code for America network activities, events, and digital forums, at the discretion of the event organizer or forum administrator.</p>
+              
+                <p>Harassment includes but is not limited to: offensive verbal or written comments related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, religion; sexual images in public spaces; deliberate intimidation; stalking; following; harassing photography or recording; sustained disruption of talks or other events; inappropriate physical contact; unwelcome sexual attention; unwarranted exclusion; and patronizing language or action.</p>
+              
+                <p>If a participant engages in harassing behavior, the organizers may take any action they deem appropriate, including warning the offender or expulsion from Code for San Jose network activities, events, and digital forums.</p>
+               
+                <p>If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact Code for San Jose Captains <a href="mailto:sharedadmin@codeforsanjose.org">on our shared email</a>.</p> 
+              
+                <p>Event staff or forum administrators will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the event.</p>
+              
+                <p>If you cannot reach an event organizer or forum administrator and/or it is an emergency, please call 911 and/or remove yourself from the situation.</p>
+              
+                <p>You can also contact Code for America about harassment at safespace@codeforamerica.org and feel free to use the email template below. Code for America staff acknowledge that we are not always in a position to evaluate a given situation due to the number of events and the fact that our team is not always present. However, we are hopeful that by providing these guidelines we are establishing a community that jointly adheres to these values and can provide an environment that is welcoming to all.</p>
+              
+                <p>We value your attendance and hope that by communicating these expectations widely we can all enjoy a harassment-free environment.</p>
+              
+                <hr>
+              
+                <h3>Email Template for Anti-Harassment Reporting</h3>
+              
+                <p>SUBJECT: Safe Space alert at [EVENT NAME]</p>
+              
+                <p>I am writing because of harassment at a Code for San Jose Communities event, (NAME, PLACE, DATE OF EVENT).</p>
+              
+                <p>You can reach me at (CONTACT INFO). Thank you.</p>
+              
+                <hr>
+              
+              </div>
+              
+            </body>
+</html>


### PR DESCRIPTION
- Got the previous code of conduct page from the Way Back Archive
- Copied and pasted the content after reviewing for any broken or out of date links and contact info

### :scroll: Description
this resolves issue  Code of Conduct page missing #75 
We may want to have an email for FAQ that people can reach out to instead of shared-admin