### PR TITLE
Fix Discord link tooltip

### DIFF
--- a/about.html
+++ b/about.html
@@ -47,7 +47,7 @@
         <div id="sociallinks">
           <a class="tooltip" href="https://discord.gg/twUAEPq8tS" target="_blank" rel="noopener noref">
             <img src="./assets/img/social_logos/Discord_Mark.png" alt="Discord logo" class="socialnav" />
-            <span class="tooltiptext">Slack</span>
+            <span class="tooltiptext">Discord</span>
           </a>
           <a class="tooltip" href="https://codeforsanjose.slack.com/" target="_blank" rel="noopener noref">
             <img src="./assets/img/social_logos/Slack_Mark.svg" alt="Slack logo" class="socialnav" />


### PR DESCRIPTION
This link points to Discord, not Slack.