### PR TITLE
Fix Discord tooltip

### DIFF
--- a/faq.html
+++ b/faq.html
@@ -49,7 +49,7 @@
                 <div id="sociallinks">
                     <a class="tooltip" href="https://discord.gg/twUAEPq8tS" target="_blank" rel="noopener noref">
                         <img src="./assets/img/social_logos/Discord_Mark.png" alt="Discord logo" class="socialnav" />
-                        <span class="tooltiptext">Slack</span>
+                        <span class="tooltiptext">Discord</span>
                       </a>
                     <a class="tooltip" href="https://codeforsanjose.slack.com/" target="_blank" rel="noopener noref">
                         <img src="./assets/img/social_logos/Slack_Mark.svg" alt="Slack logo" class="socialnav" />

--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@
         <div id="sociallinks">
           <a class="tooltip" href="https://discord.gg/twUAEPq8tS" target="_blank" rel="noopener noref">
             <img src="./assets/img/social_logos/Discord_Mark.png" alt="Discord logo" class="socialnav" />
-            <span class="tooltiptext">Slack</span>
+            <span class="tooltiptext">Discord</span>
           </a>
           <a class="tooltip" href="https://codeforsanjose.slack.com/" target="_blank" rel="noopener noref">
             <img src="./assets/img/social_logos/Slack_Mark.svg" alt="Slack logo" class="socialnav" />

--- a/projects.html
+++ b/projects.html
@@ -53,7 +53,7 @@
                 <div id="sociallinks">
                     <a class="tooltip" href="https://discord.gg/twUAEPq8tS" target="_blank" rel="noopener noref">
                         <img src="./assets/img/social_logos/Discord_Mark.png" alt="Discord logo" class="socialnav" />
-                        <span class="tooltiptext">Slack</span>
+                        <span class="tooltiptext">Discord</span>
                       </a>
                     <a class="tooltip" href="https://codeforsanjose.slack.com/" target="_blank" rel="noopener noref">
                         <img src="./assets/img/social_logos/Slack_Mark.svg" alt="Slack logo" class="socialnav" />

--- a/volunteer.html
+++ b/volunteer.html
@@ -49,7 +49,7 @@
         <div id="sociallinks">
           <a class="tooltip" href="https://discord.gg/twUAEPq8tS" target="_blank" rel="noopener noref">
             <img src="./assets/img/social_logos/Discord_Mark.png" alt="Discord logo" class="socialnav" />
-            <span class="tooltiptext">Slack</span>
+            <span class="tooltiptext">Discord</span>
           </a>
           <a class="tooltip" href="https://codeforsanjose.slack.com/" target="_blank" rel="noopener noref">
             <img src="./assets/img/social_logos/Slack_Mark.svg" alt="Slack logo" class="socialnav" />


### PR DESCRIPTION
Corrected the Discord icon’s tooltip to say “Discord” instead of “Slack”.

Fixes #91.