### PR TITLE
Update Twitter user name

### DIFF
--- a/about.html
+++ b/about.html
@@ -63,7 +63,7 @@
             <img src="./assets/img/social_logos/f_logo_RGB-Blue_512.png" alt="Facebook logo" class="socialnav" />
             <span class="tooltiptext">Facebook</span>
           </a>
-          <a class="tooltip" href="https://twitter.com/codeforsanjose" target="_blank" rel="noopener noref">
+          <a class="tooltip" href="https://twitter.com/OpenSourceSJ" target="_blank" rel="noopener noref">
             <img src="./assets/img/social_logos/Twitter_Social_Icon_Circle_Color.svg" alt="Twitter logo"
               class="socialnav" />
             <span class="tooltiptext">Twitter</span>

--- a/cut.html
+++ b/cut.html
@@ -149,7 +149,7 @@
                     <a href="https://www.facebook.com/codeforsanjose/" target="_blank" rel="noopener noref">Facebook</a>
                     <a href="https://medium.com/code-for-san-jose" target="_blank" rel="noopener noref">Medium</a>
                     <a href="https://github.com/codeforsanjose/" target="_blank" rel="noopener noref">Github</a>
-                    <a href="https://twitter.com/codeforsanjose" target="_blank" rel="noopener noref">Twitter</a>
+                    <a href="https://twitter.com/OpenSourceSJ" target="_blank" rel="noopener noref">Twitter</a>
                 </div>
             </div>
             <div id="legal">

--- a/faq.html
+++ b/faq.html
@@ -67,7 +67,7 @@
                             class="socialnav" />
                         <span class="tooltiptext">Facebook</span>
                     </a>
-                    <a class="tooltip" href="https://twitter.com/codeforsanjose" target="_blank" rel="noopener noref">
+                    <a class="tooltip" href="https://twitter.com/OpenSourceSJ" target="_blank" rel="noopener noref">
                         <img src="./assets/img/social_logos/Twitter_Social_Icon_Circle_Color.svg" alt="Twitter logo"
                             class="socialnav" />
                         <span class="tooltiptext">Twitter</span>

--- a/index.html
+++ b/index.html
@@ -89,7 +89,7 @@
             <img src="./assets/img/social_logos/f_logo_RGB-Blue_512.png" alt="Facebook logo" class="socialnav" />
             <span class="tooltiptext">Facebook</span>
           </a>
-          <a class="tooltip" href="https://twitter.com/codeforsanjose" target="_blank" rel="noopener noref">
+          <a class="tooltip" href="https://twitter.com/OpenSourceSJ" target="_blank" rel="noopener noref">
             <img src="./assets/img/social_logos/Twitter_Social_Icon_Circle_Color.svg" alt="Twitter logo"
               class="socialnav" />
             <span class="tooltiptext">Twitter</span>

--- a/projects.html
+++ b/projects.html
@@ -71,7 +71,7 @@
                             class="socialnav" />
                         <span class="tooltiptext">Facebook</span>
                     </a>
-                    <a class="tooltip" href="https://twitter.com/codeforsanjose" target="_blank" rel="noopener noref">
+                    <a class="tooltip" href="https://twitter.com/OpenSourceSJ" target="_blank" rel="noopener noref">
                         <img src="./assets/img/social_logos/Twitter_Social_Icon_Circle_Color.svg" alt="Twitter logo"
                             class="socialnav" />
                         <span class="tooltiptext">Twitter</span>

--- a/volunteer.html
+++ b/volunteer.html
@@ -63,7 +63,7 @@
             <img src="./assets/img/social_logos/f_logo_RGB-Blue_512.png" alt="Facebook logo" class="socialnav" />
             <span class="tooltiptext">Facebook</span>
           </a>
-          <a class="tooltip" href="https://twitter.com/codeforsanjose" target="_blank" rel="noopener noref">
+          <a class="tooltip" href="https://twitter.com/OpenSourceSJ" target="_blank" rel="noopener noref">
             <img src="./assets/img/social_logos/Twitter_Social_Icon_Circle_Color.svg" alt="Twitter logo"
               class="socialnav" />
             <span class="tooltiptext">Twitter</span>


### PR DESCRIPTION
Following up on #93, this PR updates every Twitter link to the point to the newly renamed [@OpenSourceSJ](https://twitter.com/OpenSourceSJ) account.