### PR TITLE
Configure Bluesky handle

### DIFF
--- a/bluesky
+++ b/bluesky
@@ -1,0 +1,5 @@
+---
+layout: none
+permalink: /.well-known/atproto-did
+---
+did:plc:afeqqceyxqcdrazzjox3k7oc


### PR DESCRIPTION
This PR adds a file associating the opensourcesanjose.org domain with [a Bluesky account](https://bsky.app/profile/opensourcesanjose.sfba.social.ap.brid.gy) that bridges our Mastodon account via [Bridgy Fed](https://fed.brid.gy/). I followed [the Bridgy Fed documentation](https://fed.brid.gy/docs#bluesky-enhanced) and [this blog post](https://seanthegeek.net/posts/how-to-verify-your-jekyll-site-on-bluesky/).