### PR TITLE
Clean up 501(c)(3) status, hack night description

### DIFF
--- a/index.html
+++ b/index.html
@@ -119,7 +119,7 @@
       <div class="text-content" id="home-about">
         <h3>Who we are...</h3>
         <p>
-          <strong>We are a volunteer civic innovation 501c3 status Non profit 99-4612294</strong> organization welcoming
+          <strong>We are a nonprofit volunteer civic innovation</strong> organization welcoming
           everyone interested in solving community problems in San José, California through technology, UX research, UI
           designs, and community partnerships.
         </p>
@@ -176,19 +176,17 @@
           <img src="./assets/img/sponsor_logos/microsoft logo.png" alt="Microsoft Logo">
           <img src="./assets/img/sponsor_logos/awesome foundation.png" alt="Awesome Foundation Logo">
         </div>
-        <!-- <p class="text-content">We host our hack nights at ActionSpot, a local co-working studio and startup incubator.
-          Organizations interested in membership at ActionSpot can contact Olga Buchonina</p> -->
+        <p class="text-content">Open Source San José is a 501(c)(3) nonprofit organization.
+          Our federal <abbr title="Employer Identification Number">EIN</abbr> is 99-4612294.
+          Your generous donations are eligible for charitable deductions under Internal Revenue Code section 170.</p>
       </div>
       <div id="find-us">
         <div class="h2bar"></div>
         <h2>Find Us</h2>
         <div class="text-content">
-          <p class="notify">In response to the Covid-19 pandemic, we are currently holding hack nights virtually. Please
-            see our
-            Meetup page or join our Discord Server for details and registration links.</p>
-          <p>Open Source San José typically meets 4th Thursday a month at 6:30pm.
-            <!-- at ActionSpot (453 W. San Carlos St).  -->
-            For our next event, see our Meetup Or Event Bright page.</p>
+          <p class="notify">Please see our Eventbrite page or join our Discord server for up-to-date details and registration links.</p>
+          <p>Open Source San José typically meets the fourth Thursday of the month at 6:30 pm.
+            Individual project teams may meet more regularly at other times.</p>
           <p>Anyone can join! Technical skills are not required to contribute. We onboard new members at
             every meeting.</p>
         </div>


### PR DESCRIPTION
Copyedited the homepage. Moved the EIN down to the section on sponsors, which is where people would more likely look for this information. Updated the events section to remove references to Meetup and COVID-19, since not all of our meetings are virtual anymore. Noted that some teams like [OSM](https://github.com/codeforsanjose/OSM-SouthBay/) are also meeting on a different schedule.